### PR TITLE
fix(vercel/prisma): force-dynamic API, prisma generate, binaryTargets, db guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,8 @@ The application accepts the following optional variables:
 - `DATABASE_URL`
 
 Configure these under **Project → Settings → Environment Variables** in Vercel. Missing values will only trigger a warning at runtime and will not block the build.
+
+## Deployment
+
+- Build command: `npm run build` (default on Vercel).
+- Prisma Client is generated automatically during install via the `postinstall` script.

--- a/app/api/portfolio/analyze/route.ts
+++ b/app/api/portfolio/analyze/route.ts
@@ -9,6 +9,8 @@ import {
 } from "@/lib/portfolio/analysisEngine";
 
 export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
 
 const BodySchema = z.object({
   positions: z.array(

--- a/app/api/portfolio/import/route.ts
+++ b/app/api/portfolio/import/route.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import { fetchBalances } from "@/lib/portfolio/adapters/etherscanLike";
 
 export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
 
 const Schema = z.object({
   addresses: z.array(z.object({ chain: z.string(), address: z.string() })),

--- a/app/api/portfolio/save/route.ts
+++ b/app/api/portfolio/save/route.ts
@@ -6,6 +6,8 @@ import { prisma } from "@/lib/prisma";
 import { fetchSimplePrices } from "@/lib/prices/coingecko";
 
 export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
 
 const BodySchema = z.object({
   label: z.string().default("Mon portefeuille"),
@@ -27,6 +29,14 @@ export async function POST(req: Request) {
   const session = await getServerSession(authOptions);
   if (!session || !session.user?.email) {
     return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  if (!process.env.DATABASE_URL) {
+    console.warn("[portfolio/save] DATABASE_URL manquant – skip DB write");
+    return NextResponse.json(
+      { ok: false, reason: "db-disabled" },
+      { status: 200 }
+    );
   }
 
   try {

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,13 +1,16 @@
 import { PrismaClient } from "@prisma/client";
 
-if (!process.env.DATABASE_URL) {
-  console.warn("DATABASE_URL environment variable is not set.");
-}
-
-const globalForPrisma = global as unknown as { prisma?: PrismaClient };
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined;
+};
 
 export const prisma =
-  globalForPrisma.prisma ||
-  new PrismaClient({ log: process.env.NODE_ENV === "development" ? ["query"] : [] });
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log:
+      process.env.NODE_ENV === "development"
+        ? ["query", "error", "warn"]
+        : ["error"],
+  });
 
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "react": "19.1.0",
@@ -31,5 +32,8 @@
   },
   "engines": {
     "node": ">=18.17 <=22"
+  },
+  "prisma": {
+    "schema": "prisma/schema.prisma"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4,7 +4,8 @@ datasource db {
 }
 
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "debian-openssl-3.0.x"]
 }
 
 model User {


### PR DESCRIPTION
## Summary
- avoid build-time execution by marking portfolio API routes as dynamic and guarding database writes when `DATABASE_URL` is missing
- generate Prisma Client on install and target the correct engine for Vercel
- document environment variables, build command, and postinstall Prisma generation

## Testing
- `npm ci`
- `npm run build`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_68a63e9d0e74832f932dd4d2cbc45041